### PR TITLE
Native lib loading

### DIFF
--- a/src/main/java/org/sputnikdev/bluetooth/manager/transport/tinyb/TinyBFactory.java
+++ b/src/main/java/org/sputnikdev/bluetooth/manager/transport/tinyb/TinyBFactory.java
@@ -55,23 +55,53 @@ public class TinyBFactory implements BluetoothObjectFactory {
     private static final ExecutorService NOTIFICATION_SERVICE = Executors.newCachedThreadPool();
 
     /**
-     * Loads TinyB native libraries from classpath by copying them to a temp folder.
+     * Loads TinyB bundeled native libraries from classpath by copying them to a temp folder.
      * @return true if all libraries succesefully loaded, false otherwise
      */
-    public static boolean loadNativeLibraries() {
-        if (NativesLoader.isSupportedEnvironment()) {
+    private static boolean loadBundeledNativeLibraries() {
+        if (!NativesLoader.isSupportedEnvironment()) {
+            return false;
+        }
+
+        final String[] libs = {"libtinyb.so", "libjavatinyb.so"};
+        for (String lib : libs) {
             try {
-                System.load(NativesLoader.prepare("libtinyb.so")); // $COVERAGE-IGNORE$
-                System.load(NativesLoader.prepare("libjavatinyb.so")); // $COVERAGE-IGNORE$
-                return true; // $COVERAGE-IGNORE$
+                System.load(NativesLoader.prepare(lib)); // $COVERAGE-IGNORE$
             } catch (Throwable e) {
-                LOGGER.info("Could not load TinyB native libraries.", e);
+                LOGGER.info("Could not load bundled TinyB native libraries.", e);
                 return false;
             }
         }
-        LOGGER.info("TinyB: environemnt is not supported. Only Linux OS; x86, x86_64 and arm6 architectures; "
-            + "are supported.");
-        return false;
+        return true; // $COVERAGE-IGNORE$
+    }
+
+    /**
+     * Loads TinyB native libraries from system paths.
+     * @return true if all libraries succesefully loaded, false otherwise
+     */
+    private static boolean loadSystemNativeLibraries() {
+        LOGGER.info("TinyB: environment is not supported out of the box. Attempting to load system libs.");
+
+        final String[] libs = {"tinyb", "javatinyb"};
+        for (String lib : libs) {
+            try {
+                System.loadLibrary(lib); // $COVERAGE-IGNORE$
+            } catch (Throwable e) {
+                LOGGER.info("TinyB: Could not load system libraries. Thus, environemnt is not supported. "
+                    + "Only Linux OS; x86, x86_64 and arm6 architectures are supported out of the box. Consider "
+                    + "providing own " + lib + ". in one of " + System.getProperty("java.library.path"), e);
+                return false;
+            }
+        }
+        return true; // $COVERAGE-IGNORE$
+    }
+
+    /**
+     * Loads TinyB native libraries (either bundeled or system ones).
+     * @return true if all libraries succesefully loaded, false otherwise
+     */
+    public static boolean loadNativeLibraries() {
+        return loadBundeledNativeLibraries() || loadSystemNativeLibraries();
     }
 
     @Override

--- a/src/test/java/org/sputnikdev/bluetooth/manager/transport/tinyb/NativesLoaderTest.java
+++ b/src/test/java/org/sputnikdev/bluetooth/manager/transport/tinyb/NativesLoaderTest.java
@@ -13,9 +13,14 @@ public class NativesLoaderTest {
 
     @Test
     public void tesetIsSupportedEnvironment() {
+        /* supported checks both OS and arch */
+        System.setProperty("os.arch", "amd64");
         System.setProperty("os.name", "linux blah blah v1");
         assertTrue(NativesLoader.isSupportedEnvironment());
         System.setProperty("os.name", "Bindows blah blah v0.1");
+        assertFalse(NativesLoader.isSupportedEnvironment());
+        System.setProperty("os.arch", "aarch64");
+        System.setProperty("os.name", "linux blah blah v1");
         assertFalse(NativesLoader.isSupportedEnvironment());
     }
 
@@ -43,12 +48,21 @@ public class NativesLoaderTest {
         assertEquals("/native/linux/x86_64", NativesLoader.getLibFolder());
         System.setProperty("os.arch", "armblahblah");
         assertEquals("/native/arm/armv6", NativesLoader.getLibFolder());
+        System.setProperty("os.arch", "i486");
+        assertEquals("/native/linux/x86_32", NativesLoader.getLibFolder());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetLibFolderAarch64() throws Exception {
+        System.setProperty("os.name", "linux blah blah v1");
+        System.setProperty("os.arch", "aarch64");
+        NativesLoader.getLibFolder();
     }
 
     @Test
     public void testIsARM() throws Exception {
         System.setProperty("os.arch", "Armv6");
-        assertTrue(NativesLoader.isARM());
+        assertTrue(NativesLoader.isARM6());
     }
 
     @Test
@@ -60,13 +74,23 @@ public class NativesLoaderTest {
     }
 
     @Test
-    public void testIs64Bit() throws Exception {
+    public void testIsX86_64() throws Exception {
         System.setProperty("os.arch", "x86_64");
-        assertTrue(NativesLoader.is64Bit());
+        assertTrue(NativesLoader.isX86_64());
         System.setProperty("os.arch", "Amd64");
-        assertTrue(NativesLoader.is64Bit());
+        assertTrue(NativesLoader.isX86_64());
         System.setProperty("os.arch", "x86");
-        assertFalse(NativesLoader.is64Bit());
+        assertFalse(NativesLoader.isX86_64());
+    }
+
+    @Test
+    public void testIsX86_32() throws Exception {
+        System.setProperty("os.arch", "x86_64");
+        assertFalse(NativesLoader.isX86_32());
+        System.setProperty("os.arch", "Amd64");
+        assertFalse(NativesLoader.isX86_32());
+        System.setProperty("os.arch", "x86");
+        assertTrue(NativesLoader.isX86_32());
     }
 
 }


### PR DESCRIPTION
Hi,

I was, at first, a bit stuck on bringing up the bluetooth base functionality. I later discovered that original code was using x86_32 native libraries on any unrecognized cpu architecture. Needless to say, x86_32 native does not work on aarch64.

The first commit renames the is* methods of NativeLoader, mirroring the architecture they check for. It also changes semantics of the isSupportedEnvironment.
The second commit attempts to load native libraries from system paths, in case the bundled loading fails.